### PR TITLE
Add support for collective.indexing, CMFPlone.indexing and prevent redirects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add collective.indexing / CMFPlone.indexing support. [busykoala]
+- Set status code to prevent redirect and the loss of the flamegraph. [busykoala]
 
 
 1.1.0 (2017-07-18)

--- a/ftw/flamegraph/__init__.py
+++ b/ftw/flamegraph/__init__.py
@@ -79,6 +79,8 @@ def publish_module_standard(
             processQueue()
 
         response.stdout = response_stdout
+        # do not redirect (otherwise the flamegraph is lost)
+        response.setStatus(200)
 
         svg_file_path = make_svg(sampler)
         with open(svg_file_path, 'rb') as f:


### PR DESCRIPTION
We do not want to redirect and lose the flamegraph. This allows us to look e.g. at transitions.

Also, I added support for collective.indexing / CMFPlone.indexing.